### PR TITLE
Updating for libsemigroups 0.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libsemigroups" %}
-{% set version = "0.5.0" %}
-{% set sha256 = "4b6d06f8f9a015df0cd8c4fe91335d1cfc65a660f46127c627d6a18f013f61f5" %}
+{% set version = "0.5.1" %}
+{% set sha256 = "b75819f1e45ebc800b7b710ad7f83b3d45c90ef51ac976e5bed5e25b07b52bae" %}
 {% set repo = "https://github.com/james-d-mitchell/libsemigroups" %}
 {% set home = "https://james-d-mitchell.github.io/libsemigroups/" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libsemigroups" %}
-{% set version = "0.5.1" %}
-{% set sha256 = "b75819f1e45ebc800b7b710ad7f83b3d45c90ef51ac976e5bed5e25b07b52bae" %}
+{% set version = "0.5.2" %}
+{% set sha256 = "740417f50416fa78c3e96ed3c44ba443878791265bc2f34a1d70016c75448866" %}
 {% set repo = "https://github.com/james-d-mitchell/libsemigroups" %}
 {% set home = "https://james-d-mitchell.github.io/libsemigroups/" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libsemigroups" %}
-{% set version = "0.4.1" %}
-{% set sha256 = "c5533d3c8ee24447d3af528e277485c21bc46650ab5fffba69967a17893a69d1" %}
+{% set version = "0.5.0" %}
+{% set sha256 = "4b6d06f8f9a015df0cd8c4fe91335d1cfc65a660f46127c627d6a18f013f61f5" %}
 {% set repo = "https://github.com/james-d-mitchell/libsemigroups" %}
 {% set home = "https://james-d-mitchell.github.io/libsemigroups/" %}
 


### PR DESCRIPTION
I've added some code so that `thread_local` is not used when compiling with GCC 4.8.* since there is a compiler error when this is used in this old version of GCC. 